### PR TITLE
Translate "Basic Operators"

### DIFF
--- a/es/basic-operators.markdown
+++ b/es/basic-operators.markdown
@@ -1,0 +1,115 @@
+---
+section: getting-started
+layout: getting-started
+title: Basic operators
+---
+
+En el [capítulo anterior](/getting-started/basic-types.html), vimos que Elixir provee los operadores aritméticos: `+`, `-`, `*`, `/`. Además las funciones `div/2` para división entera y `rem/2`para obtener el resto de una división.
+
+Elixir provee además `++` y `--` para manipular listas:
+
+```elixir
+iex> [1, 2, 3] ++ [4, 5, 6]
+[1, 2, 3, 4, 5, 6]
+iex> [1, 2, 3] -- [2]
+[1, 3]
+```
+
+La concatenación de cadenas se realiza con `<>`:
+
+```elixir
+iex> "foo" <> "bar"
+"foobar"
+```
+
+Elixir provee además tres operadores booleanos: `or`, `and` y `not`:
+
+```elixir
+iex> true and true
+true
+iex> false or is_atom(:example)
+true
+iex> not true
+false
+```
+
+Estos operadores son estrictos en cuanto a que esperan operandos booleanos, es decir, algo que evalúe o bien a `true`, o a `false`, como primer argumento. Si se provee un operando no booleano, se emitirá una excepción:
+
+```elixir
+iex> 1 and true
+** (BadBooleanError) expected a boolean on left-side of "and", got: 1
+iex> 1 or false
+** (BadBooleanError) expected a boolean on left-side of "or", got: 1
+iex> not 1
+** (ArgumentError) argument error
+```
+
+`or` y `and` son operadores que evitan realizar la evaluación del segundo argumento si el primero resulta suficiente para determinar el resultado.
+
+```elixir
+iex> false and raise("This error will never be raised")
+false
+iex> true or raise("This error will never be raised")
+true
+```
+
+Además de estos operadores booleanos, Elixir provee además `||`, `&&` y `!`, que aceptan argumentos de cualquier tipo. Para estos operadores todos los valores, exceptuando `false` y `nil` evalúan a verdadero:
+
+```elixir
+# or
+iex> 1 || true
+1
+iex> false || 11
+11
+
+# and
+iex> nil && 13
+nil
+iex> true && 17
+17
+
+# not
+iex> !true
+false
+iex> !1
+false
+iex> !nil
+true
+```
+
+Como regla general, usa `and`, `or` y `not` cuando esperes booleanos. Y si cualquiera de los argumentos puede ser no-booleano, entonces usa `&&`, `||` y `!`.
+
+Los operadores de comparación son: `==`, `!=`, `===`, `!==`, `<=`, `>=`, `<` y `>`:
+
+```elixir
+iex> 1 == 1
+true
+iex> 1 != 2
+true
+iex> 1 < 2
+true
+```
+
+La diferencia entre `==` y `===` es que el segundo es estricto al comparar entre números enteros y flotantes:
+
+```elixir
+iex> 1 == 1.0
+true
+iex> 1 === 1.0
+false
+```
+
+En Elixir podemos comparar dos tipos de datos diferentes:
+
+```elixir
+iex> 1 < :atom
+true
+```
+
+La razón de ser de esta característica es pragmatismo. De esta manera los algoritmos de ordenamiento no necesitan preocuparse de los distintos tipos de datos al ordenar. El orden de los distintos tipos de datos es el siguiente:
+
+    number < atom < reference < function < port < pid < tuple < map < list < bitstring
+
+No es necesario memorizar esto, es suficiente saber que existe. Para mayor información mira la página de [operadores](https://hexdocs.pm/elixir/operators.html) en el manual de referencia.
+
+En el próximo capítulo, discutiremos _pattern matching_ mediante el uso de `=`, que en Elixir se denomina "el operador de _match_ (emparejamiento)".

--- a/es/pattern-matching.markdown
+++ b/es/pattern-matching.markdown
@@ -1,0 +1,206 @@
+---
+section: getting-started
+layout: getting-started
+title: Pattern matching
+---
+
+**Nota del traductor:** el término _pattern matching_ en inglés no tiene una traducción sensible en castellano, o de uso común en el ambiente informático. Debido a esto se decidió dejar la frase en inglés y además usar la palabra del inglés _match_, para indicar cuando se produce la coincidencia de patrones.
+
+En este capítulo mostraremos como el operador `=` en Elixir es, de hecho, un operador de _match_ o emparejamiento de patrones, y como usar _pattern match_ dentro de estructuras de datos. Finalmente, aprenderemos sobre el operador de fijado `^`, usado para acceder valores ligados previamente a una variable.
+
+## El operador de _match_
+
+Hemos usado el operador `=` un par de veces antes para asignar variables en Elixir:
+
+```elixir
+iex> x = 1
+1
+iex> x
+1
+```
+
+En Elixir, el operador `=` se denomina el *operador de _match_*. Veamos por qué:
+
+```elixir
+iex> x = 1
+1
+iex> 1 = x
+1
+iex> 2 = x
+** (MatchError) no match of right hand side value: 1
+```
+
+Nota que `1 = x` es una expresión válida, y que no produjo error porque tanto el lado izquierdo como el derecho del operador son iguales a 1. Cuando los operandos no coinciden, se dispara una excepción `MatchError`, como se muestra en la tercer línea.
+
+Una variable sólo puede ser asignada si se encuentra en el lado izquierdo del operador `=`:
+
+```elixir
+iex> 1 = unknown
+** (CompileError) iex:1: undefined function unknown/0
+```
+
+Dado que no se definió previamente la variable `unknown`, Elixir asume que estabas tratando de llamar a la función `unknown/0`, pero dicha función no existe.
+
+## _Pattern matching_
+
+El operador de _match_ no sólo se usa para emparejar contra valores simples, sino que también es útil para desestructurar tipos de datos más complejos. Por ejemplo, podemos hacer _pattern matching_ en tuplas:
+
+```elixir
+iex> {a, b, c} = {:hello, "world", 42}
+{:hello, "world", 42}
+iex> a
+:hello
+iex> b
+"world"
+```
+
+Un error de _match_ ocurrirá si los lados no pueden ser emparejados, por ejemplo, si las tuplas tienen tamaños diferentes:
+
+```elixir
+iex> {a, b, c} = {:hello, "world"}
+** (MatchError) no match of right hand side value: {:hello, "world"}
+```
+
+También si se comparan tipos de datos diferentes, por ejemplo, si se intenta emparejar una tupla en el lado izquierdo con una lista en el derecho:
+
+```elixir
+iex> {a, b, c} = [:hello, "world", 42]
+** (MatchError) no match of right hand side value: [:hello, "world", 42]
+```
+
+Curiosamente, podemos hacer _match_ en valores específicos. El ejemplo de código siguiente se asegura que el lado izquierdo hará _match_ sólo cuando el lado derecho sea una tupla que comience con el átomo `:ok`:
+
+```elixir
+iex> {:ok, result} = {:ok, 13}
+{:ok, 13}
+iex> result
+13
+
+iex> {:ok, result} = {:error, :oops}
+** (MatchError) no match of right hand side value: {:error, :oops}
+```
+
+Podemos hacer _pattern matching_ en listas:
+
+```elixir
+iex> [a, b, c] = [1, 2, 3]
+[1, 2, 3]
+iex> a
+1
+```
+
+Una lista además soporta hacer _matching_ en su cabeza y su cola:
+
+```elixir
+iex> [cabeza | cola] = [1, 2, 3]
+[1, 2, 3]
+iex> cabeza
+1
+iex> cola
+[2, 3]
+```
+
+De manera similar a las funciones `hd/1` y `tl/1`, no podemos hacer _match_ con el patrón `[cabeza | cola]` en listas vacías:
+
+```elixir
+iex> [cabeza | cola] = []
+** (MatchError) no match of right hand side value: []
+```
+
+El formato `[cabeza | cola]` no sólo se usa en _pattern matching_, sino que también es útil para agregar elementos al comienzo de una lista:
+
+```elixir
+iex> lista = [1, 2, 3]
+[1, 2, 3]
+iex> [0 | lista]
+[0, 1, 2, 3]
+```
+
+La técnica de _pattern matching_ permite a los desarrolladores desestructurar fácilmente tipos de datos complejos como tuplas y listas. Como veremos en los próximos capítulos, es uno de los fundamentos usados para realizar recursión en Elixir, y aplica a otros tipos de datos, como mapas (_maps_) y binarios (_binaries_).
+
+## El operador de fijado
+
+En Elixir, las variables pueden ser ligadas a nuevos valores:
+
+```elixir
+iex> x = 1
+1
+iex> x = 2
+2
+```
+
+Sin embargo, hay ocasiones en que no queremos que esto ocurra.
+
+Usa el operador de fijado `^` cuando desees hacer _pattern matching_ contra el valor ligado a la variable anteriormente, en vez de ligar un nuevo valor.
+
+```elixir
+iex> x = 1
+1
+iex> ^x = 2
+** (MatchError) no match of right hand side value: 2
+```
+
+Dado que hemos fijado el valor de `x` a 1, la segunda línea es equivalente a lo siguiente:
+
+```elixir
+iex> 1 = 2
+** (MatchError) no match of right hand side value: 2
+```
+
+Nota que vemos el mismo mensaje de error.
+
+Podemos usar el operador de fijado dentro de desestructuraciones, en tuplas y listas:
+
+```elixir
+iex> x = 1
+1
+iex> [^x, 2, 3] = [1, 2, 3]
+[1, 2, 3]
+iex> {y, ^x} = {2, 1}
+{2, 1}
+iex> y
+2
+iex> {y, ^x} = {2, 2}
+** (MatchError) no match of right hand side value: {2, 2}
+```
+
+Debido a que `x` fue ligado al valor 1 al fijarlo, el último ejemplo se podría haber escrito de la siguiente manera:
+
+```elixir
+iex> {y, 1} = {2, 2}
+** (MatchError) no match of right hand side value: {2, 2}
+```
+
+Si una variable se usa más de una vez en un patrón, todas las referencias estarán ligadas al mismo valor:
+
+```elixir
+iex> {x, x} = {1, 1}
+{1, 1}
+iex> {x, x} = {1, 2}
+** (MatchError) no match of right hand side value: {1, 2}
+```
+
+En algunas ocasiones no te importará un valor particular en un patrón. Es práctica común ligar esos valores que no te interesan a la variable `_` o a variables que comiencen con este caracter. Por ejemplo, si sólo nos interesa la cabeza de una lista, podemos asignar la cola a `_`:
+
+```elixir
+iex> [cabeza | _] = [1, 2, 3]
+[1, 2, 3]
+iex> cabeza
+1
+```
+
+La variable `_` es especial: no se puede leer su contenido. Si se intenta leer su contenido Elixir lanza una excepción de error de compilación (`CompileError`):
+
+```elixir
+iex> _
+** (CompileError) iex:1: invalid use of _. "_" represents a value to be ignored in a pattern and cannot be used in expressions
+```
+
+Aunque el _pattern matching_ nos permite realizar construcciones poderosas, su uso es limitado. Por ejemplo, no se pueden hacer llamadas a funciones en el lado izquierdo del _match_. El siguiente ejemplo es inválido:
+
+```elixir
+iex> length([1, [2], 3]) = 3
+** (CompileError) iex:1: cannot invoke remote function :erlang.length/1 inside match
+```
+
+Esto concluye la introducción a _pattern matching_. Como veremos en el próximo capítulo, _pattern matching_ es muy común en muchas construcciones del lenguaje.

--- a/es/where-to-go-next.markdown
+++ b/es/where-to-go-next.markdown
@@ -18,7 +18,7 @@ Hemos escrito una guía que abrca la construicción de una aplicación Elixir, c
 
 * [Mix y OTP](/getting-started/mix-otp/introduction-to-mix.html)
 
-Si planeas escribir tu primera biblioteca para que la usen otros desarrolladores, no olvides leer nuestras [Pautas para bibliotecas] (https://hexdocs.pm/elixir/library-guidelines.html).
+Si planeas escribir tu primera biblioteca para que la usen otros desarrolladores, no olvides leer nuestras [Pautas para bibliotecas](https://hexdocs.pm/elixir/library-guidelines.html).
 
 ## Metaprogramación
 
@@ -30,7 +30,7 @@ Elixir es un lenguaje de programación extensible y muy personalizable gracias a
 
 Tenemos una sección [Aprendizaje](/learning.html) que recomienda libros, screencasts y otros recursos para aprender Elixir y explorar el ecosistema. También existen varios recursos de Elixir, como conferencias, proyectos de código abierto u otros materiales de aprendizaje creado por la comunidad.
 
-No olvides que también puede consultar el [código fuente de Elixir] (https://github.com/elixir-lang/elixir), lo cual en su mayoria se encuentra escrito principalmente en Elixir (principalmente el directorio `lib`), o [ explore la documentación de Elixir](/docs.html).
+No olvides que también puede consultar el [código fuente de Elixir](https://github.com/elixir-lang/elixir), lo cual en su mayoria se encuentra escrito principalmente en Elixir (principalmente el directorio `lib`), o [ explore la documentación de Elixir](/docs.html).
 
 ## Un poco de Erlang
 


### PR DESCRIPTION
A revisar por algún colega:

- mi uso de "cadenas" y "enteros" en vez de mantener _string_ e _int_ como mencionan en el README. Creo que aplica, pero lo cambio si es necesario.
- sobre el final habla de "pattern matching" y la verdad que no hay traducciones sensibles que produzcan levantamiento de cejas, en general los hispanohablantes usamos el término en inglés.
- expandí un poco los ejemplos de código en la parte de los operadores booleanos, porque no estaba completamente ejemplificado. Además, en esa parte moví el texto al siquiente ejemplo, pues no calzaba con lo que se mostraba en el primero.